### PR TITLE
Us2

### DIFF
--- a/app/controllers/flight_passengers_controller.rb
+++ b/app/controllers/flight_passengers_controller.rb
@@ -1,0 +1,7 @@
+class FlightPassengersController < ApplicationController
+  def destroy
+    flightpassenger = FlightPassenger.find_by(flight_id: params[:flight_id], passenger_id: params[:passenger_id])
+    flightpassenger.destroy
+    redirect_to "/flights"
+  end
+end

--- a/app/views/flights/index.html.erb
+++ b/app/views/flights/index.html.erb
@@ -5,7 +5,9 @@
     <p><b>Passengers:</b></p>
       <ul>
         <% flight.passengers.each do |passenger| %>
-        <li><%= passenger.name %></li>
+        <li><%= passenger.name %>
+          <%= button_to "Remove #{passenger.name}", "/flights/#{flight.id}/passengers/#{passenger.id}", method: :delete %>
+        </li>
         <% end %>
       </ul>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,5 +5,5 @@ Rails.application.routes.draw do
   # root "articles#index"
 
   get "/flights", to: "flights#index"
-  
+  delete "/flights/:flight_id/passengers/:passenger_id", to: "flight_passengers#destroy"
 end

--- a/spec/features/flights/index_spec.rb
+++ b/spec/features/flights/index_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "/flights, flights index page", type: :feature do
       within "#flight-#{flight2.id}" do
         expect(page).to have_content("Flight Number: #{flight2.number} - #{frontier.name}")
       end
-      
+
       within "#flight-#{flight3.id}" do
         expect(page).to have_content("Flight Number: #{flight3.number} - #{southwest.name}")
       end
@@ -66,6 +66,58 @@ RSpec.describe "/flights, flights index page", type: :feature do
         expect(page).to_not have_content(passenger2.name)
         expect(page).to_not have_content(passenger3.name)
         expect(page).to have_content(passenger4.name)
+      end
+    end
+
+    #userstory 2
+    it "can remove passenger from flight, passenger still shows up on other flights where not removed" do
+      visit "/flights"
+
+      within "#flight-#{flight1.id}" do
+        expect(page).to have_content("#{passenger1.name}")
+        expect(page).to have_button("Remove #{passenger1.name}")
+
+        expect(page).to have_content("#{passenger2.name}")
+        expect(page).to have_button("Remove #{passenger2.name}")
+
+        expect(page).to have_content("#{passenger3.name}")
+        expect(page).to have_button("Remove #{passenger3.name}")
+
+        expect(page).to_not have_content("#{passenger4.name}")
+        expect(page).to_not have_button("Remove #{passenger4.name}")
+      end
+
+      within "#flight-#{flight2.id}" do
+        expect(page).to have_content("Flight Number: #{flight2.number} - #{frontier.name}")
+        expect(page).to_not have_button("Remove #{passenger1.name}")
+        expect(page).to_not have_button("Remove #{passenger2.name}")
+
+        expect(page).to have_content("#{passenger3.name}")
+        expect(page).to have_button("Remove #{passenger3.name}")
+
+        expect(page).to have_content("#{passenger4.name}")
+        expect(page).to have_button("Remove #{passenger4.name}")
+
+        click_button "Remove #{passenger3.name}"
+      end
+
+      expect(current_path).to eq("/flights")
+
+      within "#flight-#{flight1.id}" do
+        expect(page).to have_button("Remove #{passenger1.name}")
+        expect(page).to have_button("Remove #{passenger2.name}")
+        expect(page).to have_content("#{passenger3.name}") #passenger is still on this flight
+        expect(page).to have_button("Remove #{passenger3.name}")
+        expect(page).to_not have_button("Remove #{passenger4.name}")
+      end
+
+      within "#flight-#{flight2.id}" do
+        expect(page).to have_content("Flight Number: #{flight2.number} - #{frontier.name}")
+        expect(page).to_not have_button("Remove #{passenger1.name}")
+        expect(page).to_not have_button("Remove #{passenger2.name}")
+        expect(page).to_not have_content("#{passenger3.name}") #passenger was removed from this flight, and should not show up
+        expect(page).to_not have_button("Remove #{passenger3.name}")
+        expect(page).to have_button("Remove #{passenger4.name}")
       end
     end
   end


### PR DESCRIPTION
- add tests for button delete passengers from flights on index page
- ensure tests capture that if a passenger is deleted from one flight, still remain on other assigned flights
- add flight_passengers controller and route for destroy method
- add button_to remove passenger to the view
- rails s running as expected